### PR TITLE
Filters2

### DIFF
--- a/IdokladSdk.IntegrationTests/Tests/Clients/SalesOrder/SalesOrderTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/SalesOrder/SalesOrderTests.cs
@@ -199,6 +199,20 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.SalesOrder
         }
 
         [Test]
+        public void GetList_WithComplexFilter_SuccessfullyReturned()
+        {
+            // Act && Assert
+            var data = _client.List()
+                .Filter(f => f.DocumentNumber.Contains("005") &&
+                            (f.State.IsEqual(SalesOrderState.Created) ||
+                             f.State.IsEqual(SalesOrderState.Offered) ||
+                             f.State.IsEqual(SalesOrderState.Ordered) ||
+                             f.State.IsEqual(SalesOrderState.Invoiced)))
+                .Get()
+                .AssertResult();
+        }
+
+        [Test]
         public void GetList_WithSelect_SuccessfullyReturned()
         {
             // Act

--- a/IdokladSdk.NetCore.TestApp/Examples/SelectExamples.cs
+++ b/IdokladSdk.NetCore.TestApp/Examples/SelectExamples.cs
@@ -22,14 +22,26 @@ namespace IdokladSdk.NetCore.TestApp.Examples
             // When retrieving list of entities, we can specify filter which applies inside iDoklad and reduces amount of data transferred.
             // Expression used in Filter method allows usage only of those properties which can be filtered on server-side, it depends on
             // entity type. The same applies to properties used in Sort method.
+            // Expressions can contain multiple expressions joined by arbitrary combination of && or || operators. Use parentheses to specify
+            // precedence.
+            var list = _api.ContactClient
+                .List()
+                .Filter(c => c.DateLastChange.IsLowerThan(DateTime.UtcNow) && (c.CompanyName.Contains("a.s.") || c.CompanyName.Contains("s.r.o.")))
+                .Sort(c => c.Id.Asc())
+                .PageSize(100)
+                .Page(1)
+                .Get();
+        }
+
+        public void List_Filtering_Obsolete()
+        {
+            // Previous versions of SDK supported usage of multiple conditions in filter, but all expressions parts could be joined by the
+            // same logical operator.
             var list = _api.ContactClient
                 .List()
                 .Filter(c => c.CompanyName.Contains("company"))
                 .Filter(c => c.DateLastChange.IsGreaterThan(DateTime.UtcNow.AddMinutes(-10)))
                 .FilterType(FilterType.And)
-                .Sort(c => c.Id.Asc())
-                .PageSize(100)
-                .Page(1)
                 .Get();
         }
 

--- a/IdokladSdk.NetCore.TestApp/Program.cs
+++ b/IdokladSdk.NetCore.TestApp/Program.cs
@@ -68,6 +68,7 @@ namespace IdokladSdk.NetCore.TestApp
             select.List_GetWithGenericType_ReturnsCustomModel();
             select.List_GetWithLambda_SpecificType();
             select.List_FilteringSortingPaging();
+            select.List_Filtering_Obsolete();
             select.Detail_DefaultGetMethod_ReturnsDefaultModel(_partner1Id);
             select.Detail_GetWithGenericType_ReturnsCustomModel(_partner1Id);
             select.Detail_WithLambda_ReturningAnonymousType(_partner1Id);

--- a/IdokladSdk.UnitTests/Tests/Modifiers/FilterModifier/FilterModifierTests.cs
+++ b/IdokladSdk.UnitTests/Tests/Modifiers/FilterModifier/FilterModifierTests.cs
@@ -90,6 +90,129 @@ namespace IdokladSdk.UnitTests.Tests.Modifiers
             Assert.AreEqual("and", filterType);
         }
 
+        [Test]
+        public void FilterModifier_TwoSimpleExpressionsWithAnd_ReturnsCorrectQueryParam()
+        {
+            // Arrange
+            var modifier = new FilterModifier<TestFilter>();
+            Func<TestFilter, FilterExpression> filterExpression1 = (f) => f.Id.IsEqual(100);
+            Func<TestFilter, FilterExpression> filterExpression2 = (f) => f.Name.Contains("a.s.");
+            modifier.Filter(f => filterExpression1(f) && filterExpression2(f));
+
+            // Act
+            var queryParams = modifier.GetQueryParameters();
+
+            // Assert
+            Assert.AreEqual(1, queryParams.Count);
+            Assert.IsTrue(queryParams.TryGetValue("filter", out var filter));
+            var filter1 = GetFilterExpression(filterExpression1);
+            var filter2 = GetFilterExpression(filterExpression2);
+            Assert.AreEqual($"({filter1}~and~{filter2})", filter);
+        }
+
+        [Test]
+        public void FilterModifier_ThreeSimpleExpressionsWithOr_ReturnsCorrectQueryParam()
+        {
+            // Arrange
+            var modifier = new FilterModifier<TestFilter>();
+            Func<TestFilter, FilterExpression> filterExpression1 = (f) => f.Name.Contains("a.s.");
+            Func<TestFilter, FilterExpression> filterExpression2 = (f) => f.Name.Contains("s.r.o.");
+            Func<TestFilter, FilterExpression> filterExpression3 = (f) => f.Name.Contains("k.s.");
+            modifier.Filter(f => filterExpression1(f) || filterExpression2(f) || filterExpression3(f));
+
+            // Act
+            var queryParams = modifier.GetQueryParameters();
+
+            // Assert
+            Assert.AreEqual(1, queryParams.Count);
+            Assert.IsTrue(queryParams.TryGetValue("filter", out var filter));
+            var filter1 = GetFilterExpression(filterExpression1);
+            var filter2 = GetFilterExpression(filterExpression2);
+            var filter3 = GetFilterExpression(filterExpression3);
+            Assert.AreEqual($"(({filter1}~or~{filter2})~or~{filter3})", filter);
+        }
+
+        [Test]
+        public void FilterModifier_ComplexExpression_ReturnsCorrectQueryParam()
+        {
+            // Arrange
+            var modifier = new FilterModifier<TestFilter>();
+            Func<TestFilter, FilterExpression> filterExpression1 = (f) => f.Id.IsEqual(100);
+            Func<TestFilter, FilterExpression> filterExpression2 = (f) => f.Name.Contains("a.s.");
+            Func<TestFilter, FilterExpression> filterExpression3 = (f) => f.Name.Contains("s.r.o.");
+            Func<TestFilter, FilterExpression> filterExpression4 = (f) => f.Name.Contains("s.r.o.");
+            Func<TestFilter, FilterExpression> filterExpression5 = (f) => f.Date.IsLowerThan(new DateTime(2020, 1, 1));
+            modifier.Filter(f => (filterExpression1(f) && (filterExpression2(f) || filterExpression3(f) || filterExpression4(f))) || filterExpression5(f));
+
+            // Act
+            var queryParams = modifier.GetQueryParameters();
+
+            // Assert
+            Assert.AreEqual(1, queryParams.Count);
+            Assert.IsTrue(queryParams.TryGetValue("filter", out var filter));
+            var filter1 = GetFilterExpression(filterExpression1);
+            var filter2 = GetFilterExpression(filterExpression2);
+            var filter3 = GetFilterExpression(filterExpression3);
+            var filter4 = GetFilterExpression(filterExpression4);
+            var filter5 = GetFilterExpression(filterExpression5);
+            Assert.AreEqual($"(({filter1}~and~(({filter2}~or~{filter3})~or~{filter4}))~or~{filter5})", filter);
+        }
+
+        [Test]
+        public void FilterModifier_AddSimpleFilterAfterComplexFilter_ThrowsException()
+        {
+            // Arrange
+            var modifier = new FilterModifier<TestFilter>();
+            modifier.Filter(f => f.Name.Contains("a.s.") || f.Name.Contains("s.r.o."));
+
+            // Act + Assert
+            Assert.Throws<InvalidOperationException>(() => modifier.Filter(f => f.Id.IsEqual(1)));
+        }
+
+        [Test]
+        public void FilterModifier_AddComplexFilterAfterSimpleFilter_ThrowsException()
+        {
+            // Arrange
+            var modifier = new FilterModifier<TestFilter>();
+            modifier.Filter(f => f.Id.IsEqual(1));
+
+            // Act + Assert
+            Assert.Throws<InvalidOperationException>(() => modifier.Filter(f => f.Name.Contains("a.s.") || f.Name.Contains("s.r.o.")));
+        }
+
+        [Test]
+        public void FilterModifier_AddComplexFilterAfterComplexFilter_ThrowsException()
+        {
+            // Arrange
+            var modifier = new FilterModifier<TestFilter>();
+            modifier.Filter(f => f.Name.Contains("a.s.") || f.Name.Contains("s.r.o."));
+
+            // Act + Assert
+            Assert.Throws<InvalidOperationException>(() => modifier.Filter(f => f.Name.Contains("aaa") || f.Name.Contains("bbb")));
+        }
+
+        [Test]
+        public void FilterModifier_AddComplexFilterAfterFilterType_ThrowsException()
+        {
+            // Arrange
+            var modifier = new FilterModifier<TestFilter>();
+            modifier.FilterType(FilterType.Or);
+
+            // Act + Assert
+            Assert.Throws<InvalidOperationException>(() => modifier.Filter(f => f.Name.Contains("a.s.") || f.Name.Contains("s.r.o.")));
+        }
+
+        [Test]
+        public void FilterModifier_AddFilterTypeAfterComplexFilter_ThrowsException()
+        {
+            // Arrange
+            var modifier = new FilterModifier<TestFilter>();
+            modifier.Filter(f => f.Name.Contains("a.s.") || f.Name.Contains("s.r.o."));
+
+            // Act + Assert
+            Assert.Throws<InvalidOperationException>(() => modifier.FilterType(FilterType.And));
+        }
+
         private string GetFilterExpression(Func<TestFilter, FilterExpression> filter)
         {
             var filterableObject = new TestFilter();

--- a/IdokladSdk/Requests/Core/BaseList.cs
+++ b/IdokladSdk/Requests/Core/BaseList.cs
@@ -78,6 +78,17 @@ namespace IdokladSdk.Requests.Core
         }
 
         /// <summary>
+        /// Filter for a list.
+        /// </summary>
+        /// <param name="filter">Filter expressions.</param>
+        /// <returns>List of models.</returns>
+        public TList Filter(Func<TFilter, FilterExpressionBase> filter)
+        {
+            _filter.Filter(filter);
+            return This;
+        }
+
+        /// <summary>
         /// Filter type for a list.
         /// </summary>
         /// <param name="filterType">Filter type.</param>

--- a/IdokladSdk/Requests/Core/Modifiers/Filters/Common/ComplexFilterExpression.cs
+++ b/IdokladSdk/Requests/Core/Modifiers/Filters/Common/ComplexFilterExpression.cs
@@ -1,0 +1,29 @@
+﻿namespace IdokladSdk.Requests.Core.Modifiers.Filters.Common
+{
+    /// <summary>
+    /// Complex filter expression.
+    /// </summary>
+    public class ComplexFilterExpression : FilterExpressionBase
+    {
+        /// <summary>
+        /// Gets or sets first expression.
+        /// </summary>
+        internal FilterExpressionBase FirstExpression { get; set; }
+
+        /// <summary>
+        /// Gets or sets second expression.
+        /// </summary>
+        internal FilterExpressionBase SecondExpression { get; set; }
+
+        /// <summary>
+        /// Gets or sets operator (AND, OR).
+        /// </summary>
+        internal FilterType LogicalOperator { get; set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"({FirstExpression}~{LogicalOperator.ToString().ToLowerInvariant()}~{SecondExpression})";
+        }
+    }
+}

--- a/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterExpression.cs
+++ b/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterExpression.cs
@@ -6,7 +6,7 @@ namespace IdokladSdk.Requests.Core.Modifiers.Filters.Common
     /// <summary>
     /// Filter expression.
     /// </summary>
-    public class FilterExpression
+    public class FilterExpression : FilterExpressionBase
     {
         private readonly string _name;
         private readonly FilterOperator _operator;

--- a/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterExpressionBase.cs
+++ b/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterExpressionBase.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace IdokladSdk.Requests.Core.Modifiers.Filters.Common
+{
+    /// <summary>
+    /// Filter expression base class.
+    /// </summary>
+    public abstract class FilterExpressionBase
+    {
+        /// <summary>
+        /// Operator true.
+        /// </summary>
+        /// <param name="expression">Expression.</param>
+        /// <returns>False (to prevent short-circuit evaluation of conditional logical and).</returns>
+        public static bool operator true(FilterExpressionBase expression)
+        {
+            _ = expression;
+            return false;
+        }
+
+        /// <summary>
+        /// Operator False.
+        /// </summary>
+        /// <param name="expression">Expression.</param>
+        /// <returns>False (to prevent short-circuit evaluation of conditional logical or).</returns>
+        public static bool operator false(FilterExpressionBase expression)
+        {
+            _ = expression;
+            return false;
+        }
+
+        /// <summary>
+        /// Custom AND operator.
+        /// </summary>
+        /// <param name="lhs">Left expression.</param>
+        /// <param name="rhs">Right expression.</param>
+        /// <returns>Expressions combined with AND operator.</returns>
+        public static FilterExpressionBase operator &(FilterExpressionBase lhs, FilterExpressionBase rhs)
+        {
+            return JoinFilterExpression(lhs, rhs, FilterType.And);
+        }
+
+        /// <summary>
+        /// Custom OR operator.
+        /// </summary>
+        /// <param name="lhs">Left expression.</param>
+        /// <param name="rhs">Right expression.</param>
+        /// <returns>Expressions combined with OR operator.</returns>
+        public static FilterExpressionBase operator |(FilterExpressionBase lhs, FilterExpressionBase rhs)
+        {
+            return JoinFilterExpression(lhs, rhs, FilterType.Or);
+        }
+
+        private static FilterExpressionBase JoinFilterExpression(
+            FilterExpressionBase firstExpression,
+            FilterExpressionBase secondExpression,
+            FilterType logicalOperator)
+        {
+            return new ComplexFilterExpression
+            {
+                FirstExpression = firstExpression,
+                SecondExpression = secondExpression,
+                LogicalOperator = logicalOperator
+            };
+        }
+    }
+}

--- a/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterItem.cs
+++ b/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterItem.cs
@@ -13,7 +13,6 @@
         public FilterItem(string name)
             : base(name)
         {
-            Name = name;
         }
 
         /// <summary>

--- a/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterItemBase.cs
+++ b/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterItemBase.cs
@@ -3,13 +3,13 @@
     /// <summary>
     /// Filter item base class.
     /// </summary>
-    public class FilterItemBase
+    public abstract class FilterItemBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FilterItemBase"/> class.
         /// </summary>
         /// <param name="name">Item name.</param>
-        public FilterItemBase(string name)
+        protected FilterItemBase(string name)
         {
             Name = name;
         }

--- a/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterModifier.cs
+++ b/IdokladSdk/Requests/Core/Modifiers/Filters/Common/FilterModifier.cs
@@ -13,9 +13,11 @@ namespace IdokladSdk.Requests.Core.Modifiers.Filters.Common
     public class FilterModifier<TFilter> : IQueryStringModifier
         where TFilter : new()
     {
-        private readonly HashSet<FilterExpression> _filters = new HashSet<FilterExpression>();
+        private readonly HashSet<FilterExpression> _simpleFilters = new HashSet<FilterExpression>();
 
-        private FilterType _filterType = Common.FilterType.And;
+        private ComplexFilterExpression _complexFilter = null;
+
+        private FilterType? _filterType = null;
 
         /// <summary>
         /// Add filter.
@@ -23,39 +25,121 @@ namespace IdokladSdk.Requests.Core.Modifiers.Filters.Common
         /// <param name="filters">Filters.</param>
         public void Filter(params Func<TFilter, FilterExpression>[] filters)
         {
+            CheckExistingComplexFilter();
+
             var filterableObject = new TFilter();
 
             foreach (var filter in filters)
             {
-                var filterExpression = filter.Invoke(filterableObject);
-                _filters.Add(filterExpression);
+                var simpleFilter = filter.Invoke(filterableObject);
+                _simpleFilters.Add(simpleFilter);
+            }
+        }
+
+        /// <summary>
+        /// Add filter.
+        /// </summary>
+        /// <param name="filter">Filter.</param>
+        public void Filter(Func<TFilter, FilterExpressionBase> filter)
+        {
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+
+            var filterableObject = new TFilter();
+            var filterExpression = filter.Invoke(filterableObject);
+
+            if (filterExpression is ComplexFilterExpression complexFilter)
+            {
+                AddComplexFilter(complexFilter);
+            }
+            else if (filterExpression is FilterExpression simpleFilter)
+            {
+                AddSimpleFilter(simpleFilter);
             }
         }
 
         /// <summary>
         /// Set filter type.
         /// </summary>
-        /// <param name="filterType">Tilter type.</param>
+        /// <param name="filterType">Filter type.</param>
         public void FilterType(FilterType filterType)
         {
+            if (_complexFilter != null)
+            {
+                throw new InvalidOperationException("Cannot specify filter type when complex filter expression is used.");
+            }
+
             _filterType = filterType;
         }
 
         /// <inheritdoc/>
         public Dictionary<string, string> GetQueryParameters()
         {
-            if (!_filters.Any())
+            if (_complexFilter != null)
             {
-                return null;
+                return GetQueryParametersComplexFilter();
+            }
+            else if (_simpleFilters.Any())
+            {
+                return GetQueryParametersSimpleFilters();
             }
 
-            var filter = string.Join("|", _filters);
-            var filterType = _filterType.ToString().ToLower(CultureInfo.InvariantCulture);
+            return null;
+        }
+
+        private void AddComplexFilter(ComplexFilterExpression complexFilter)
+        {
+            if (_simpleFilters.Any())
+            {
+                throw new InvalidOperationException("Individual item filters have already been used, cannot add complex filter expression.");
+            }
+
+            if (_complexFilter != null)
+            {
+                throw new InvalidOperationException("Only single complex expression is allowed.");
+            }
+
+            if (_filterType.HasValue)
+            {
+                throw new InvalidOperationException($"Complex filter expression cannot be used together with {nameof(FilterType)} method.");
+            }
+
+            _complexFilter = complexFilter;
+        }
+
+        private void AddSimpleFilter(FilterExpression simpleFilter)
+        {
+            CheckExistingComplexFilter();
+            _simpleFilters.Add(simpleFilter);
+        }
+
+        private void CheckExistingComplexFilter()
+        {
+            if (_complexFilter != null)
+            {
+                throw new InvalidOperationException("Complex filter expression has already been used, cannot add another expression filters.");
+            }
+        }
+
+        private Dictionary<string, string> GetQueryParametersComplexFilter()
+        {
+            var filter = _complexFilter.ToString();
 
             return new Dictionary<string, string>()
             {
                 { "filter", filter },
-                { "filterType", filterType }
+            };
+        }
+
+        private Dictionary<string, string> GetQueryParametersSimpleFilters()
+        {
+            var filter = string.Join("|", _simpleFilters);
+            var filterType = _filterType ?? Common.FilterType.And;
+            var filterTypeStr = filterType.ToString().ToLower(CultureInfo.InvariantCulture);
+
+            return new Dictionary<string, string>()
+            {
+                { "filter", filter },
+                { "filterType", filterTypeStr }
             };
         }
     }


### PR DESCRIPTION
Složené filtry
- skládání se provádí pomocí && a ||, tedy běžná C# syntaxe
- díky realizaci pomocí operátorů se vyhodnocuje podle priorit a závorek
- vygenerovaný výraz může mít více závorek - při připojení výrazu k již složenému výrazu se stávající složený výraz vloží do závorek, nicméně vzhledem k pořadí vyhodnocování by tyto nadbytečné závorky neměly změnit vyhodnocování výrazu; toto je vidět v testech
- úplně se mi nelíbí, že složený výraz je typu FilterExpressionBase, chtěl jsem, aby byl ComplexExpressionBase, ale aby se daly používat operátory, tak vlastní operátory pro & a | musí mít stejný typ výsledku jako parametrů a parametry musí být FilterExpressionBase (společný předek pro jednoduchý a složený výraz)