### PR TITLE
SalesReceipt - added ItemType property to SalesReceiptItemListGetModel

### DIFF
--- a/IdokladSdk.IntegrationTests/Tests/Clients/SalesReceipt/SalesReceiptTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/SalesReceipt/SalesReceiptTests.cs
@@ -67,6 +67,8 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.SalesReceipt
             // Assert
             Assert.AreEqual(_salesReceiptId, data.Id);
             Assert.AreEqual(_postModel.Note, data.Note);
+            Assert.True(data.Items.Any(i => i.ItemType == SalesReceiptItemType.ItemTypeNormal));
+            Assert.True(data.Items.Any(i => i.ItemType == SalesReceiptItemType.ItemTypeRound));
         }
 
         [Test]

--- a/IdokladSdk/Models/SalesReceipt/List/SalesReceiptItemListGetModel.cs
+++ b/IdokladSdk/Models/SalesReceipt/List/SalesReceiptItemListGetModel.cs
@@ -22,6 +22,11 @@ namespace IdokladSdk.Models.SalesReceipt
         public int Id { get; set; }
 
         /// <summary>
+        /// Gets or sets item type.
+        /// </summary>
+        public SalesReceiptItemType ItemType { get; set; }
+
+        /// <summary>
         /// Gets or sets name.
         /// </summary>
         public string Name { get; set; }


### PR DESCRIPTION
ItemType chyběla i v API, kam se doplnila dodatečně, ale nějak se zapomnělo na její přidání do SDK.