### PR TITLE
Removed EmptyOrWhiteSpace validation on DiscountName and Code properties on IssuedInvoiceItemPatchModel

### DIFF
--- a/IdokladSdk/Models/IssuedInvoice/Patch/IssuedInvoiceItemPatchModel.cs
+++ b/IdokladSdk/Models/IssuedInvoice/Patch/IssuedInvoiceItemPatchModel.cs
@@ -21,14 +21,12 @@ namespace IdokladSdk.Models.IssuedInvoice
         /// Gets or sets item code.
         /// </summary>
         [StringLength(20)]
-        [NotEmptyString]
         public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets discount name.
         /// </summary>
         [StringLength(200)]
-        [NotEmptyString]
         public string DiscountName { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Protože naše API vrací v defaultních modelech ve stringových hodnotách prázdné stringy a ne null, tak při přeuložení od mApp API vracelo chybu kvůli EmptyOrWhiteSpace atributu.
Zatím jsme nepřišli na nějaké triviální řešení, proto jsem zatím atribut z problémových propert odstranil.