### PR TITLE
Fixed handling server error in selector function applying

### DIFF
--- a/IdokladSdk/Requests/Core/BaseList.cs
+++ b/IdokladSdk/Requests/Core/BaseList.cs
@@ -178,8 +178,8 @@ namespace IdokladSdk.Requests.Core
                 Data = new Page<TResult>
                 {
                     Items = apiResult.Data?.Items?.Select(o => selectorFunction.Invoke(o)),
-                    TotalItems = apiResult.Data.TotalItems,
-                    TotalPages = apiResult.Data.TotalPages
+                    TotalItems = apiResult.Data?.TotalItems ?? 0,
+                    TotalPages = apiResult.Data?.TotalPages ?? 0
                 },
                 ErrorCode = apiResult.ErrorCode,
                 IsSuccess = apiResult.IsSuccess,


### PR DESCRIPTION
Při internal server erroru byl apiResult.Data null a tím pádem výsledek skončil výjimkou.