### PR TITLE
Fixed tests

### DIFF
--- a/IdokladSdk.IntegrationTests/Core/Tags/TaggableDocumentTestsBase.cs
+++ b/IdokladSdk.IntegrationTests/Core/Tags/TaggableDocumentTestsBase.cs
@@ -25,7 +25,7 @@ namespace IdokladSdk.IntegrationTests.Core.Tags
     {
         protected const int PartnerId = 323824;
 
-        private readonly List<int> _entityIdsToDelete = new List<int>();
+        private readonly List<int> _entityIdsToDelete = new ();
 
         [SetUp]
         public void SetUp()
@@ -34,12 +34,11 @@ namespace IdokladSdk.IntegrationTests.Core.Tags
         }
 
         [TearDown]
-        public void TearDown()
+        public async Task TearDown()
         {
-            foreach (var id in _entityIdsToDelete)
-            {
-                DeleteAsync(id);
-            }
+            var tasks = _entityIdsToDelete.Select(DeleteAsync);
+
+            await Task.WhenAll(tasks);
         }
 
         [Test]

--- a/IdokladSdk.IntegrationTests/Tests/Clients/CreditNote/CreditNoteTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/CreditNote/CreditNoteTests.cs
@@ -283,7 +283,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.CreditNote
             Assert.AreEqual(patchModel.EetResponsibility, getModel.EetResponsibility);
             Assert.AreEqual(patchModel.ExchangeRate, getModel.ExchangeRate);
             Assert.AreEqual(patchModel.ExchangeRateAmount, getModel.ExchangeRateAmount);
-            Assert.AreEqual(patchModel.IsEet, getModel.IsEet);
+            Assert.AreEqual(patchModel.IsEet.GetValueOrDefault(), getModel.IsEet);
             Assert.AreEqual(patchModel.IsIncomeTax, getModel.IsIncomeTax);
             var getModelNormalItems = getModel.Items.Where(i => i.ItemType == IssuedInvoiceItemType.ItemTypeNormal)
                 .ToList();
@@ -506,7 +506,6 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.CreditNote
                 ExchangeRate = 10,
                 ExchangeRateAmount = 10,
                 Id = _postedCreditNoteId,
-                IsEet = true,
                 IsIncomeTax = true,
                 Items = new List<CreditNoteItemPatchModel>
             {


### PR DESCRIPTION
- v TearDown bol problém ten, že sa nezmazali všetky vytvorené faktúry, takže to zbytočne zaberalo miesto
- EET je odstránené, takže nemá zmysel to nastavovať