### PR TITLE
Issued document template ItemType

### DIFF
--- a/IdokladSdk.IntegrationTests/Tests/Clients/IssuedDocumentTemplate/IssuedDocumentTemplateTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/IssuedDocumentTemplate/IssuedDocumentTemplateTests.cs
@@ -212,7 +212,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.IssuedDocumentTemplate
 
             // Assert
             var itemToRecount = model.Items.First();
-            var recountedItem = data.Items.First(x => x.ItemType == RecurringInvoiceItemGetType.ItemTypeNormal);
+            var recountedItem = data.Items.First(x => x.ItemType == IssuedDocumentTemplateItemType.ItemTypeNormal);
             Assert.That(recountedItem.Id, Is.EqualTo(itemToRecount.Id));
             Assert.That(recountedItem.Name, Is.EqualTo(itemToRecount.Name));
             Assert.That(recountedItem.Prices.TotalWithVat, Is.EqualTo(242));
@@ -245,7 +245,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.IssuedDocumentTemplate
                         new IssuedDocumentTemplateItemPatchModel
                         {
                             Name = "added item",
-                            ItemType = PostIssuedInvoiceItemType.ItemTypeNormal
+                            ItemType = PostIssuedDocumentTemplateItemType.ItemTypeNormal
                         }
                     }
             };

--- a/IdokladSdk/Enums/IssuedDocumentTemplateItemType.cs
+++ b/IdokladSdk/Enums/IssuedDocumentTemplateItemType.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IdokladSdk.Enums
+{
+    public enum IssuedDocumentTemplateItemType
+    {
+        /// <summary>
+        /// Normal issued document template item
+        /// </summary>
+        ItemTypeNormal = 0,
+
+        /// <summary>
+        /// Round issued document template item
+        /// </summary>
+        ItemTypeRound = 1,
+
+        /// <summary>
+        /// Reduced item for accounted by proforma invoices
+        /// </summary>
+        ItemTypeReduce = 2
+    }
+}

--- a/IdokladSdk/Enums/PostIssuedDocumentTemplateItemType.cs
+++ b/IdokladSdk/Enums/PostIssuedDocumentTemplateItemType.cs
@@ -1,0 +1,18 @@
+﻿namespace Doklad.Shared.Enums.Api
+{
+    /// <summary>
+    /// PostIssuedInvoiceItemType.
+    /// </summary>
+    public enum PostIssuedDocumentTemplateItemType
+    {
+        /// <summary>
+        /// Normal issued document template item
+        /// </summary>
+        ItemTypeNormal = 0,
+
+        /// <summary>
+        /// Reduced item for accounted by proforma invoices
+        /// </summary>
+        ItemTypeReduce = 2
+    }
+}

--- a/IdokladSdk/Models/IssuedDocumentTemplate/List/IssuedDocumentTemplateListItemGetModel.cs
+++ b/IdokladSdk/Models/IssuedDocumentTemplate/List/IssuedDocumentTemplateListItemGetModel.cs
@@ -20,7 +20,7 @@ namespace IdokladSdk.Models.IssuedDocumentTemplate.List
         /// <summary>
         /// Gets or sets item type.
         /// </summary>
-        public PostIssuedInvoiceItemType ItemType { get; set; }
+        public IssuedDocumentTemplateItemType ItemType { get; set; }
 
         /// <summary>
         /// Gets or sets item name.

--- a/IdokladSdk/Models/IssuedDocumentTemplate/Patch/IssuedDocumentTemplateItemPatchModel.cs
+++ b/IdokladSdk/Models/IssuedDocumentTemplate/Patch/IssuedDocumentTemplateItemPatchModel.cs
@@ -22,7 +22,7 @@ namespace IdokladSdk.Models.IssuedDocumentTemplate.Patch
         /// <summary>
         /// Gets or sets item type.
         /// </summary>
-        public PostIssuedInvoiceItemType? ItemType { get; set; }
+        public PostIssuedDocumentTemplateItemType? ItemType { get; set; }
 
         /// <summary>
         /// Gets or sets item name.

--- a/IdokladSdk/Models/IssuedDocumentTemplate/Post/IssuedDocumentTemplateItemPostModel.cs
+++ b/IdokladSdk/Models/IssuedDocumentTemplate/Post/IssuedDocumentTemplateItemPostModel.cs
@@ -19,7 +19,7 @@ namespace IdokladSdk.Models.IssuedDocumentTemplate.Post
         /// <summary>
         /// Gets or sets item type.
         /// </summary>
-        public PostIssuedInvoiceItemType ItemType { get; set; }
+        public PostIssuedDocumentTemplateItemType ItemType { get; set; }
 
         /// <summary>
         /// Gets or sets item name.

--- a/IdokladSdk/Models/IssuedDocumentTemplate/Recount/IssuedDocumentTemplateItemRecountGetModel.cs
+++ b/IdokladSdk/Models/IssuedDocumentTemplate/Recount/IssuedDocumentTemplateItemRecountGetModel.cs
@@ -19,7 +19,7 @@ namespace IdokladSdk.Models.IssuedDocumentTemplate.Recount
         /// <summary>
         /// Gets or sets item type.
         /// </summary>
-        public RecurringInvoiceItemGetType ItemType { get; set; }
+        public IssuedDocumentTemplateItemType ItemType { get; set; }
 
         /// <summary>
         /// Gets or sets item name.


### PR DESCRIPTION
Hlavní změna: Nový enum IssuedDocumentTemplateItemType který obsahuje i Round ItemType. API tento typ položky vrací pro detail ale v modelu IssuedDocumentTemplateItemGetModel to nebylo podchyceno.