### PR TITLE
ProformaInvoice Accounting model

### DIFF
--- a/IdokladSdk.IntegrationTests/Tests/Clients/IssuedInvoice/IssuedInvoiceTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/IssuedInvoice/IssuedInvoiceTests.cs
@@ -54,7 +54,8 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.IssuedInvoice
             _issuedInvoicePostModel.Items.Add(new IssuedInvoiceItemPostModel
             {
                 Name = "Test",
-                UnitPrice = 100
+                UnitPrice = 100,
+                Amount = 1
             });
 
             // Act

--- a/IdokladSdk.IntegrationTests/Tests/Clients/PriceListItem/PriceListItemTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/PriceListItem/PriceListItemTests.cs
@@ -233,7 +233,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.PriceListItem
                 Price = 200,
                 PriceType = PriceType.WithVat,
                 Unit = "kg",
-                VatRateType = VatRateType.Reduced2,
+                VatRateType = VatRateType.Reduced1,
                 VatCodeId = 2
             };
         }

--- a/IdokladSdk.IntegrationTests/Tests/Clients/ProformaInvoice/ProformaInvoiceTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/ProformaInvoice/ProformaInvoiceTests.cs
@@ -189,7 +189,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.ProformaInvoice
 
         [Test]
         [Order(6)]
-        public async Task GetInvoiceForAccount_SuccessfullyGetIssuedInvoiceAccountPostModelAsync()
+        public async Task GetInvoiceForAccount_SuccessfullyGetIssuedInvoiceDefaultGetModelAsync()
         {
             // Act
             var data = await _proformaInvoiceClient.GetInvoiceForAccountAsync(_proformaInvoiceId).AssertResult();
@@ -199,6 +199,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.ProformaInvoice
             Assert.That(item, Is.Not.Null);
             Assert.That(data.ProformaInvoices, Is.Not.Null.And.Count.EqualTo(1).And.Contains(_proformaInvoiceId));
             Assert.That(item.UnitPrice, Is.EqualTo(-100));
+            Assert.That(data.VatRegime, Is.EqualTo(VatRegime.VatRegime));
         }
 
         [Test]

--- a/IdokladSdk/Clients/ProformaInvoiceClient.cs
+++ b/IdokladSdk/Clients/ProformaInvoiceClient.cs
@@ -109,10 +109,10 @@ namespace IdokladSdk.Clients
         /// <param name="id">Proforma invoice id.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Method return issued invoice post model for account proforma invoice.</returns>
-        public Task<ApiResult<IssuedInvoicePostModel>> GetInvoiceForAccountAsync(int id, CancellationToken cancellationToken = default)
+        public Task<ApiResult<IssuedInvoiceDefaultGetModel>> GetInvoiceForAccountAsync(int id, CancellationToken cancellationToken = default)
         {
             var resource = $"{ResourceUrl}/{id}/Account";
-            return GetAsync<IssuedInvoicePostModel>(resource, null, cancellationToken);
+            return GetAsync<IssuedInvoiceDefaultGetModel>(resource, null, cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
V rámci úprav pole VatRegime se to pole přidávalo na vícero míst v SDK, kde vznikly nové 'DefaultGet' modely

Nicméně pro vyúčtování zálohové faktury, zůstal model původní a informace v něm chybí. Dle API tam pole je