### PR TITLE
Fix cash voucher tests - changed test cach voucher Id

### DIFF
--- a/IdokladSdk.IntegrationTests/Tests/Clients/CashVoucher/CashVoucherTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/CashVoucher/CashVoucherTests.cs
@@ -18,7 +18,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.CashVoucher
     [TestFixture]
     public class CashVoucherTests : TestBase
     {
-        private const int CashVoucherId = 587154;
+        private const int CashVoucherId = 640075;
         private const int PartnerId = 323823;
         private const int UnpaidIssuedInvoice = 914456;
         private const int UnpaidReceivedInvoice = 165460;
@@ -67,7 +67,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.CashVoucher
 
             // Assert
             Assert.That(cashVoucher.Id, Is.EqualTo(CashVoucherId));
-            Assert.That(cashVoucher.Items.First().Price, Is.EqualTo(500m));
+            Assert.That(cashVoucher.Items.First().Price, Is.EqualTo(150m));
         }
 
         [Test]

--- a/IdokladSdk.IntegrationTests/Tests/Clients/Report/ReportImageTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/Report/ReportImageTests.cs
@@ -94,7 +94,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.Report
         public async Task GetImageAsync_CashVoucherDetail_SuccessfullyGetAsyncReport()
         {
             var data = await _reportClient.CashVoucher
-                .Detail(587154)
+                .Detail(640075)
                 .GetImageAsync(new ReportImageOption
                 {
                     Language = Language.Cz

--- a/IdokladSdk.IntegrationTests/Tests/Clients/Report/ReportTests.cs
+++ b/IdokladSdk.IntegrationTests/Tests/Clients/Report/ReportTests.cs
@@ -86,7 +86,7 @@ namespace IdokladSdk.IntegrationTests.Tests.Clients.Report
         [Test]
         public async Task GetAsync_CashVoucherDetail_SuccessfullyGetAsyncReport()
         {
-            var data = await _reportClient.CashVoucher.Detail(587154).GetAsync(new ReportOption
+            var data = await _reportClient.CashVoucher.Detail(640075).GetAsync(new ReportOption
             {
                 Language = Language.Cz
             }).AssertResult();


### PR DESCRIPTION
Promazával jsem namnožená data z agendy, ale smazal jsem i pokladní doklad, který se používal v testu. Nahradil jsem ho proto jiným.