### PR TITLE
Sales Orders - send via link

### DIFF
--- a/IdokladSdk/Clients/SalesOrderClient.cs
+++ b/IdokladSdk/Clients/SalesOrderClient.cs
@@ -18,7 +18,7 @@ namespace IdokladSdk.Clients
     /// </summary>
     public class SalesOrderClient :
         BaseClient,
-        ICopyRequest<SalesOrderDefaultGetModel>,
+        ICopyRequest<SalesOrderCopyGetModel>,
         IDeleteRequest,
         IEntityDetail<SalesOrderDetail>,
         IEntityList<SalesOrderList>,
@@ -41,10 +41,10 @@ namespace IdokladSdk.Clients
         public override string ResourceUrl { get; } = "/SalesOrders";
 
         /// <inheritdoc />
-        public Task<ApiResult<SalesOrderDefaultGetModel>> CopyAsync(int id, CancellationToken cancellationToken = default)
+        public Task<ApiResult<SalesOrderCopyGetModel>> CopyAsync(int id, CancellationToken cancellationToken = default)
         {
             var resource = $"{ResourceUrl}/{id}/Copy";
-            return GetAsync<SalesOrderDefaultGetModel>(resource, null, cancellationToken);
+            return GetAsync<SalesOrderCopyGetModel>(resource, null, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/IdokladSdk/Enums/SalesOrderState.cs
+++ b/IdokladSdk/Enums/SalesOrderState.cs
@@ -28,6 +28,11 @@
         /// <summary>
         /// Rejected.
         /// </summary>
-        Rejected = 4
+        Rejected = 4,
+
+        /// <summary>
+        /// Expired.
+        /// </summary>
+        Expired = 5
     }
 }

--- a/IdokladSdk/Models/SalesOrder/Copy/SalesOrderCopyGetModel.cs
+++ b/IdokladSdk/Models/SalesOrder/Copy/SalesOrderCopyGetModel.cs
@@ -9,7 +9,7 @@ namespace IdokladSdk.Models.SalesOrder
     /// <summary>
     /// SalesOrder Model for Copy endpoint.
     /// </summary>
-    public class SalesOrderCopyGetModel : SalesOrderPostModel
+    public class SalesOrderCopyGetModel
     {
         /// <summary>
         /// Gets or sets account number.

--- a/IdokladSdk/Models/SalesOrder/Copy/SalesOrderCopyGetModel.cs
+++ b/IdokladSdk/Models/SalesOrder/Copy/SalesOrderCopyGetModel.cs
@@ -2,15 +2,14 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using IdokladSdk.Enums;
-using IdokladSdk.Models.Base;
 using IdokladSdk.Validation.Attributes;
 
 namespace IdokladSdk.Models.SalesOrder
 {
     /// <summary>
-    /// SalesOrder Model for Post endpoints.
+    /// SalesOrder Model for Copy endpoint.
     /// </summary>
-    public class SalesOrderPostModel : ValidatableModel
+    public class SalesOrderCopyGetModel : SalesOrderPostModel
     {
         /// <summary>
         /// Gets or sets account number.
@@ -85,7 +84,7 @@ namespace IdokladSdk.Models.SalesOrder
         /// </summary>
         [MinCollectionLength(1)]
         [Required]
-        public List<SalesOrderItemPostModel> Items { get; set; }
+        public List<SalesOrderItemCopyModel> Items { get; set; }
 
         /// <summary>
         /// Gets or sets items text prefix.
@@ -121,11 +120,6 @@ namespace IdokladSdk.Models.SalesOrder
         public int PartnerId { get; set; }
 
         /// <summary>
-        /// Gets or sets status of sending the sales receipt to the purchaser.
-        /// </summary>
-        public MailSentType PurchaserSentStatus { get; set; }
-
-        /// <summary>
         /// Gets or sets swift code.
         /// </summary>
         [StringLength(11)]
@@ -140,5 +134,10 @@ namespace IdokladSdk.Models.SalesOrder
         /// Gets or sets tags.
         /// </summary>
         public List<int> Tags { get; set; }
+
+        /// <summary>
+        /// Gets or sets Vat regime.
+        /// </summary>
+        public VatRegime VatRegime { get; set; }
     }
 }

--- a/IdokladSdk/Models/SalesOrder/Copy/SalesOrderItemCopyModel.cs
+++ b/IdokladSdk/Models/SalesOrder/Copy/SalesOrderItemCopyModel.cs
@@ -1,0 +1,62 @@
+﻿using System.ComponentModel.DataAnnotations;
+using IdokladSdk.Enums;
+using IdokladSdk.Validation.Attributes;
+
+namespace IdokladSdk.Models.SalesOrder
+{
+    /// <summary>
+    /// SalesOrderItem Model for Copy endpoint.
+    /// </summary>
+    public class SalesOrderItemCopyModel
+    {
+        /// <summary>
+        /// Gets or sets item amount.
+        /// </summary>
+        [Required]
+        [DecimalRange]
+        public decimal Amount { get; set; }
+
+        /// <summary>
+        /// Gets or sets item name.
+        /// </summary>
+        [Required(AllowEmptyStrings = false)]
+        [StringLength(200)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets price list item id.
+        /// </summary>
+        [NullableForeignKey]
+        public int? PriceListItemId { get; set; }
+
+        /// <summary>
+        /// Gets or sets price type.
+        /// </summary>
+        [Required]
+        public PriceType PriceType { get; set; }
+
+        /// <summary>
+        /// Gets or sets unit of measure.
+        /// </summary>
+        [StringLength(20)]
+        public string Unit { get; set; }
+
+        /// <summary>
+        /// Gets or sets unit price.
+        /// </summary>
+        [Required]
+        public decimal UnitPrice { get; set; }
+
+        /// <summary>
+        /// Gets or sets vAT rate type.
+        /// </summary>
+        [Required]
+        public VatRateType VatRateType { get; set; }
+
+        /// <summary>
+        /// Gets or sets vat code id.
+        /// </summary>
+        [NullableForeignKey]
+        public int? VatCodeId { get; set; }
+    }
+}

--- a/IdokladSdk/Models/SalesOrder/List/SalesOrderListGetModel.cs
+++ b/IdokladSdk/Models/SalesOrder/List/SalesOrderListGetModel.cs
@@ -127,6 +127,11 @@ namespace IdokladSdk.Models.SalesOrder
         public Prices Prices { get; set; }
 
         /// <summary>
+        /// Gets or sets status of sending the sales receipt to the purchaser.
+        /// </summary>
+        public MailSentType PurchaserSentStatus { get; set; }
+
+        /// <summary>
         /// Gets or sets state.
         /// </summary>
         public SalesOrderState State { get; set; }


### PR DESCRIPTION
Implements API changes for sending Sales order via link.

**Breaking change**: SalesOrderClient.CopyAsync now returns SalesOrderCopyGetModel instead of SalesOrderDefaultGetModel.